### PR TITLE
Update Cake.Powershell versions

### DIFF
--- a/nuspec/Cake.Services.nuspec
+++ b/nuspec/Cake.Services.nuspec
@@ -22,7 +22,7 @@
 
       <dependencies>
          <dependency id="Cake.Core" version="0.11.0" />
-         <dependency id="Cake.Powershell" version="0.2.3" />
+         <dependency id="Cake.Powershell" version="0.3.5" />
          <dependency id="Microsoft.PowerShell.5.ReferenceAssemblies" version="1.0.0" />
       </dependencies>
    </metadata>

--- a/src/Services.Tests/Cake.Services.Tests.csproj
+++ b/src/Services.Tests/Cake.Services.Tests.csproj
@@ -43,8 +43,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Cake.Powershell, Version=0.2.8.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Powershell.0.2.8\lib\net45\Cake.Powershell.dll</HintPath>
-      <Private>True</Private>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Cake.Powershell.0.3.5\lib\net45\Cake.Powershell.dll</HintPath>
     </Reference>
     <Reference Include="NSubstitute, Version=1.10.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
       <HintPath>..\packages\NSubstitute.1.10.0.0\lib\net45\NSubstitute.dll</HintPath>

--- a/src/Services.Tests/packages.config
+++ b/src/Services.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Cake.Core" version="0.17.0" targetFramework="net45" />
-  <package id="Cake.Powershell" version="0.2.8" targetFramework="net45" />
+  <package id="Cake.Powershell" version="0.3.5" targetFramework="net45" />
   <package id="Microsoft.PowerShell.5.ReferenceAssemblies" version="1.0.0" targetFramework="net45" />
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />

--- a/src/Services/Cake.Services.csproj
+++ b/src/Services/Cake.Services.csproj
@@ -36,9 +36,8 @@
       <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Cake.Powershell, Version=0.3.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Powershell.0.3.1\lib\net45\Cake.Powershell.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Cake.Powershell">
+      <HintPath>..\packages\Cake.Powershell.0.3.5\lib\net45\Cake.Powershell.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Services/packages.config
+++ b/src/Services/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Cake.Core" version="0.17.0" targetFramework="net45" />
-  <package id="Cake.Powershell" version="0.3.1" targetFramework="net45" />
+  <package id="Cake.Powershell" version="0.3.5" targetFramework="net45" />
   <package id="Microsoft.PowerShell.5.ReferenceAssemblies" version="1.0.0" targetFramework="net45" />
 </packages>

--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -6,8 +6,8 @@
 using System.Reflection;
 
 [assembly: AssemblyProduct("Cake.Services")]
-[assembly: AssemblyVersion("0.2.2")]
-[assembly: AssemblyFileVersion("0.2.2")]
-[assembly: AssemblyInformationalVersion("0.2.2")]
-[assembly: AssemblyCopyright("Copyright (c) 2015 - 2016 Phillip Sharpe")]
+[assembly: AssemblyVersion("0.2.9")]
+[assembly: AssemblyFileVersion("0.2.9")]
+[assembly: AssemblyInformationalVersion("0.2.9")]
+[assembly: AssemblyCopyright("Copyright (c) 2015 - 2017 Phillip Sharpe")]
 


### PR DESCRIPTION
Updating Cake.Powershell versions, as the current versions cause issues with the new version of Cake.